### PR TITLE
Fix team selection to ignore suspended players

### DIFF
--- a/main.py
+++ b/main.py
@@ -229,7 +229,11 @@ class LigaRecordApp:
             "5-3-2": {'Goleiro':1, 'Defesa':5, 'Médio':3, 'Avançado':2}
         }
         
-        disponiveis = self.df[(self.df['Titular'] | self.df['Suplente'] | self.df['Reserva']) & ~self.df['Lesionado']]
+        disponiveis = self.df[
+            (self.df['Titular'] | self.df['Suplente'] | self.df['Reserva'])
+            & ~self.df['Lesionado']
+            & ~self.df['Expulso']
+        ]
         equipe = pd.DataFrame()
         
         for pos, qtd in mapeamento[formacao].items():


### PR DESCRIPTION
## Summary
- exclude suspended players when picking the best eleven

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6871a94e2ab0833085cffbd0ab218d66